### PR TITLE
Feat/my ad details screen

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -18,6 +18,7 @@ module.exports = function (api) {
             '@hooks': './src/hooks',
             '@contexts': './src/contexts',
             '@routes': './src/routes',
+            '@mappers': './src/mappers',
           },
         },
       ],

--- a/src/components/AdDetails.tsx
+++ b/src/components/AdDetails.tsx
@@ -1,45 +1,34 @@
 import { Box, HStack, ScrollView, Text, VStack, useTheme } from 'native-base';
-import { ImageSlider, PhotoProps } from './ImageSlider';
+import { ImageSlider } from './ImageSlider';
 import { UserPhoto } from './UserPhoto';
-import { UserDTO } from '@dtos/UserDTO';
-import { PaymentMethodsDTO } from '@dtos/PaymentMethodsDTO';
 import { api } from '@services/api';
 import {
-  ArrowLeft,
   Bank,
   Barcode,
   CreditCard,
   Money,
   QrCode,
-  Tag,
 } from 'phosphor-react-native';
+import { IProduct } from 'src/interfaces/IProduct';
+import { toMaskedPrice } from '@utils/Masks';
+import { IPaymentMethods } from 'src/interfaces/IPaymentMethods';
 
 const PHOTO_SIZE = 6;
 
-export type AdDetailsProps = {
-  user: UserDTO;
-  title: string;
-  images: PhotoProps[];
-  description: string;
-  acceptTrade: boolean;
-  isNew: boolean;
-  paymentMethods: PaymentMethodsDTO[];
-  price: string;
-};
-
 export function AdDetails({
   user,
-  title,
-  images,
+  name,
+  product_images,
   description,
-  acceptTrade,
-  isNew,
-  paymentMethods,
+  accept_trade,
+  is_new,
+  payment_methods,
   price,
-}: AdDetailsProps) {
+  is_active = true,
+}: IProduct) {
   const { colors, sizes } = useTheme();
 
-  function paymentMethodIndicator(paymentMethod: PaymentMethodsDTO) {
+  function paymentMethodIndicator(paymentMethod: IPaymentMethods) {
     switch (paymentMethod) {
       case 'boleto':
         return (
@@ -94,7 +83,8 @@ export function AdDetails({
 
   return (
     <ScrollView showsVerticalScrollIndicator={false}>
-      <ImageSlider imagesUrl={images} />
+      <ImageSlider imagesUrl={product_images} disabled={!is_active} />
+
       <VStack px='6'>
         <HStack my='6'>
           <UserPhoto
@@ -109,7 +99,7 @@ export function AdDetails({
         </HStack>
 
         <Box
-          bg={isNew ? 'blue.400' : 'gray.300'}
+          bg={is_new ? 'blue.400' : 'gray.300'}
           rounded='full'
           px='2'
           mb='2'
@@ -118,15 +108,15 @@ export function AdDetails({
           <Text
             fontSize='xs-'
             fontFamily='bold'
-            color={isNew ? 'gray.100' : 'gray.600'}
+            color={is_new ? 'gray.100' : 'gray.600'}
           >
-            {isNew ? 'NOVO' : 'USADO'}
+            {is_new ? 'NOVO' : 'USADO'}
           </Text>
         </Box>
 
         <HStack alignItems='center' justifyContent='space-between'>
           <Text flex={1} fontFamily='bold' fontSize='lg+' color='gray.700'>
-            {title}
+            {name}
           </Text>
           <Text
             numberOfLines={1}
@@ -135,7 +125,7 @@ export function AdDetails({
             color='blue.400'
             maxWidth='1/3'
           >
-            R$ <Text fontSize='lg+'>{price}</Text>
+            R$ <Text fontSize='lg+'>{toMaskedPrice(String(price / 100))}</Text>
           </Text>
         </HStack>
 
@@ -145,14 +135,14 @@ export function AdDetails({
 
         <Text fontFamily='bold' fontSize='sm' color='gray.600' mt='4'>
           Aceita troca?{' '}
-          <Text fontFamily='regular'>{acceptTrade ? 'Sim' : 'Não'}</Text>
+          <Text fontFamily='regular'>{accept_trade ? 'Sim' : 'Não'}</Text>
         </Text>
 
         <Text fontFamily='bold' fontSize='sm' color='gray.600' mt='4'>
           Meios de pagamento:
         </Text>
 
-        {paymentMethods.map((item, index) => (
+        {payment_methods.map((item, index) => (
           <HStack key={item + String(index)} mt='1'>
             {paymentMethodIndicator(item)}
           </HStack>

--- a/src/components/ImageSlider.tsx
+++ b/src/components/ImageSlider.tsx
@@ -2,17 +2,13 @@ import React, { useRef, useState } from 'react';
 import { ViewToken, Dimensions } from 'react-native';
 import { ImageIndicator } from './ImageIndicator';
 import { Box, FlatList, HStack, Image, Text, VStack } from 'native-base';
+import { IPhoto } from 'src/interfaces/IPhoto';
 
 const { width: WIDTH } = Dimensions.get('screen');
 
-export type PhotoProps = {
-  name: string;
-  uri: string;
-  type: string;
-};
-
 type Props = {
-  imagesUrl: PhotoProps[];
+  imagesUrl: IPhoto[];
+  disabled: boolean;
 };
 
 interface ChangeImageProps {
@@ -20,7 +16,7 @@ interface ChangeImageProps {
   changed: ViewToken[];
 }
 
-export function ImageSlider({ imagesUrl }: Props) {
+export function ImageSlider({ imagesUrl, disabled }: Props) {
   const [imageIndex, setImageIndex] = useState(0);
 
   const indexChanged = useRef((info: ChangeImageProps) => {
@@ -65,6 +61,21 @@ export function ImageSlider({ imagesUrl }: Props) {
             />
           ))}
         </HStack>
+      )}
+
+      {disabled && (
+        <Box
+          position='absolute'
+          w='full'
+          h='72'
+          bg='gray.700:alpha.60'
+          alignItems='center'
+          justifyContent='center'
+        >
+          <Text fontSize='sm' fontFamily='bold' color='gray.100'>
+            ANÚNCIO DESATIVADO
+          </Text>
+        </Box>
       )}
     </VStack>
   );

--- a/src/dtos/PaymentMethodsDTO.ts
+++ b/src/dtos/PaymentMethodsDTO.ts
@@ -1,1 +1,4 @@
-export type PaymentMethodsDTO = 'pix' | 'card' | 'deposit' | 'cash' | 'boleto';
+export type PaymentMethodsDTO = {
+  key: string;
+  name: string;
+};

--- a/src/dtos/ProductDTO.ts
+++ b/src/dtos/ProductDTO.ts
@@ -1,5 +1,5 @@
 import { PaymentMethodsDTO } from './PaymentMethodsDTO';
-import { ProductImagesDTO } from './ProductImagesDTO';
+import { ProductImageDTO } from './ProductImageDTO';
 import { UserDTO } from './UserDTO';
 
 export type ProductDTO = {
@@ -10,6 +10,6 @@ export type ProductDTO = {
   price: number;
   accept_trade: boolean;
   payment_methods: PaymentMethodsDTO[];
-  product_images: ProductImagesDTO[];
+  product_images: ProductImageDTO[];
   user: UserDTO;
 };

--- a/src/dtos/ProductDTO.ts
+++ b/src/dtos/ProductDTO.ts
@@ -1,0 +1,15 @@
+import { PaymentMethodsDTO } from './PaymentMethodsDTO';
+import { ProductImagesDTO } from './ProductImagesDTO';
+import { UserDTO } from './UserDTO';
+
+export type ProductDTO = {
+  id: string;
+  name: string;
+  description: string;
+  is_new: boolean;
+  price: number;
+  accept_trade: boolean;
+  payment_methods: PaymentMethodsDTO[];
+  product_images: ProductImagesDTO[];
+  user: UserDTO;
+};

--- a/src/dtos/ProductImageDTO.ts
+++ b/src/dtos/ProductImageDTO.ts
@@ -1,0 +1,4 @@
+export type ProductImageDTO = {
+  id: string;
+  path: string;
+};

--- a/src/interfaces/IPaymentMethods.ts
+++ b/src/interfaces/IPaymentMethods.ts
@@ -1,0 +1,1 @@
+export type IPaymentMethods = 'pix' | 'card' | 'deposit' | 'cash' | 'boleto';

--- a/src/interfaces/IPhoto.ts
+++ b/src/interfaces/IPhoto.ts
@@ -1,0 +1,5 @@
+export interface IPhoto {
+  name: string;
+  uri: string;
+  type: string;
+}

--- a/src/interfaces/IProduct.ts
+++ b/src/interfaces/IProduct.ts
@@ -1,0 +1,16 @@
+import { UserDTO } from '@dtos/UserDTO';
+import { IPhoto } from './IPhoto';
+import { IPaymentMethods } from './IPaymentMethods';
+
+export interface IProduct {
+  id?: string;
+  name: string;
+  description: string;
+  is_new: boolean;
+  price: number;
+  accept_trade: boolean;
+  payment_methods: IPaymentMethods[];
+  product_images: IPhoto[];
+  is_active?: boolean;
+  user: UserDTO;
+}

--- a/src/mappers/PaymentMethodsMap.ts
+++ b/src/mappers/PaymentMethodsMap.ts
@@ -1,0 +1,12 @@
+import { PaymentMethodsDTO } from '@dtos/PaymentMethodsDTO';
+import { api } from '@services/api';
+import { IPaymentMethods } from 'src/interfaces/IPaymentMethods';
+import { IPhoto } from 'src/interfaces/IPhoto';
+
+class PaymentMethodsMap {
+  static toIPaymentMethods({ key, name }: PaymentMethodsDTO): IPaymentMethods {
+    return key as IPaymentMethods;
+  }
+}
+
+export { PaymentMethodsMap };

--- a/src/mappers/PhotoMap.ts
+++ b/src/mappers/PhotoMap.ts
@@ -1,0 +1,15 @@
+import { ProductImageDTO } from '@dtos/ProductImageDTO';
+import { api } from '@services/api';
+import { IPhoto } from 'src/interfaces/IPhoto';
+
+class PhotoMap {
+  static toIPhoto({ id, path }: ProductImageDTO): IPhoto {
+    return {
+      name: id,
+      uri: `${api.defaults.baseURL}/images/${path}`,
+      type: 'image',
+    };
+  }
+}
+
+export { PhotoMap };

--- a/src/mappers/ProductMap.ts
+++ b/src/mappers/ProductMap.ts
@@ -1,0 +1,36 @@
+import { ProductDTO } from '@dtos/ProductDTO';
+import { api } from '@services/api';
+import { IProduct } from 'src/interfaces/IProduct';
+import uuid from 'react-native-uuid';
+import { PhotoMap } from './PhotoMap';
+import { PaymentMethodsMap } from './PaymentMethodsMap';
+
+class ProductMap {
+  static toIProduct({
+    id,
+    name,
+    description,
+    is_new,
+    price,
+    accept_trade,
+    payment_methods,
+    product_images,
+    user,
+  }: ProductDTO): IProduct {
+    return {
+      id: id ?? String(uuid.v4()),
+      name,
+      description,
+      is_new,
+      price,
+      accept_trade,
+      payment_methods: payment_methods.map((item) =>
+        PaymentMethodsMap.toIPaymentMethods(item)
+      ),
+      product_images: product_images.map((item) => PhotoMap.toIPhoto(item)),
+      user,
+    };
+  }
+}
+
+export { ProductMap };

--- a/src/routes/app.routes.tsx
+++ b/src/routes/app.routes.tsx
@@ -1,115 +1,36 @@
-import {
-  createBottomTabNavigator,
-  BottomTabNavigationProp,
-} from '@react-navigation/bottom-tabs';
-import { House, Tag, SignOut } from 'phosphor-react-native';
-import { Home } from '@screens/Home';
-import { useTheme, Pressable } from 'native-base';
-import { Platform } from 'react-native';
-import { MyAds } from '@screens/MyAds';
-import { useAuth } from '@hooks/useAuth';
 import { CreateAd } from '@screens/CreateAd';
 import { PreviewAd } from '@screens/PreviewAd';
-import { UserDTO } from '@dtos/UserDTO';
-import { PaymentMethodsDTO } from '@dtos/PaymentMethodsDTO';
-import { PhotoProps } from '@components/ImageSlider';
+import { MyAdDetails } from '@screens/MyAdDetails';
+import { IProduct } from 'src/interfaces/IProduct';
+import {
+  NativeStackNavigationProp,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
+import { HomeTabsRoutes } from './home.tabs.routes';
 
 type AppRoutes = {
-  home: undefined;
-  myAds: undefined;
-  signOut: undefined;
-  createAd: undefined;
-  previewAd: {
-    user: UserDTO;
-    title: string;
-    images: PhotoProps[];
-    description: string;
-    acceptTrade: boolean;
-    isNew: boolean;
-    paymentMethods: PaymentMethodsDTO[];
-    price: string;
+  homeTabs: undefined;
+  createAd: undefined | IProduct;
+  previewAd: IProduct & {
+    imagesToDelete: string[];
   };
+  myAdDetails: { id: string };
 };
 
-export type AppNavigatorRoutesProps = BottomTabNavigationProp<AppRoutes>;
+export type AppNavigatorRoutesProps = NativeStackNavigationProp<AppRoutes>;
 
-const { Navigator, Screen } = createBottomTabNavigator<AppRoutes>();
+const { Navigator, Screen } = createNativeStackNavigator<AppRoutes>();
 
 export function AppRoutes() {
-  const { sizes, colors } = useTheme();
-  const { signOut } = useAuth();
-
-  const iconSize = sizes[6];
-
-  const LogOutFakeScreen = () => {
-    return null;
-  };
-
   return (
-    <Navigator
-      screenOptions={{
-        headerShown: false,
-        tabBarShowLabel: false,
-        tabBarActiveTintColor: colors.gray[600],
-        tabBarInactiveTintColor: colors.gray[400],
-        tabBarStyle: {
-          backgroundColor: colors.gray[200],
-          borderTopWidth: 0,
-          height: Platform.OS === 'android' ? 'auto' : 96,
-          paddingBottom: sizes[10],
-          paddingTop: sizes[6],
-        },
-      }}
-    >
-      <Screen
-        name='home'
-        component={Home}
-        options={{
-          tabBarIcon: ({ color }) => <House color={color} size={iconSize} />,
-        }}
-      />
+    <Navigator screenOptions={{ headerShown: false, gestureEnabled: false }}>
+      <Screen name='homeTabs' component={HomeTabsRoutes} />
 
-      <Screen
-        name='myAds'
-        component={MyAds}
-        options={{
-          tabBarIcon: ({ color }) => <Tag color={color} size={iconSize} />,
-        }}
-      />
+      <Screen name='createAd' component={CreateAd} />
 
-      <Screen
-        name='signOut'
-        component={LogOutFakeScreen}
-        options={{
-          tabBarIcon: () => (
-            <Pressable onPress={signOut}>
-              <SignOut color={colors.red[400]} size={iconSize} />
-            </Pressable>
-          ),
-        }}
-      />
+      <Screen name='previewAd' component={PreviewAd} />
 
-      <Screen
-        name='createAd'
-        component={CreateAd}
-        options={{
-          tabBarStyle: {
-            display: 'none',
-          },
-          tabBarButton: () => null,
-        }}
-      />
-
-      <Screen
-        name='previewAd'
-        component={PreviewAd}
-        options={{
-          tabBarStyle: {
-            display: 'none',
-          },
-          tabBarButton: () => null,
-        }}
-      />
+      <Screen name='myAdDetails' component={MyAdDetails} />
     </Navigator>
   );
 }

--- a/src/routes/home.tabs.routes.tsx
+++ b/src/routes/home.tabs.routes.tsx
@@ -1,0 +1,78 @@
+import {
+  createBottomTabNavigator,
+  BottomTabNavigationProp,
+} from '@react-navigation/bottom-tabs';
+import { House, Tag, SignOut } from 'phosphor-react-native';
+import { useTheme, Pressable } from 'native-base';
+import { Platform } from 'react-native';
+import { Home } from '@screens/Home';
+import { MyAds } from '@screens/MyAds';
+import { useAuth } from '@hooks/useAuth';
+
+type HomeTabsRoutes = {
+  home: undefined;
+  myAds: undefined;
+  signOut: undefined;
+};
+
+export type HomeTabsNavigatorRoutesProps =
+  BottomTabNavigationProp<HomeTabsRoutes>;
+
+const { Navigator, Screen } = createBottomTabNavigator<HomeTabsRoutes>();
+
+export function HomeTabsRoutes() {
+  const { sizes, colors } = useTheme();
+  const { signOut } = useAuth();
+
+  const iconSize = sizes[6];
+
+  const LogOutFakeScreen = () => {
+    return null;
+  };
+
+  return (
+    <Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarShowLabel: false,
+        tabBarActiveTintColor: colors.gray[600],
+        tabBarInactiveTintColor: colors.gray[400],
+        tabBarStyle: {
+          backgroundColor: colors.gray[200],
+          borderTopWidth: 0,
+          height: Platform.OS === 'android' ? 'auto' : 96,
+          paddingBottom: sizes[10],
+          paddingTop: sizes[6],
+        },
+      }}
+    >
+      <Screen
+        name='home'
+        component={Home}
+        options={{
+          tabBarIcon: ({ color }) => <House color={color} size={iconSize} />,
+        }}
+      />
+
+      <Screen
+        name='myAds'
+        component={MyAds}
+        options={{
+          tabBarIcon: ({ color }) => <Tag color={color} size={iconSize} />,
+        }}
+      />
+
+      <Screen
+        name='signOut'
+        component={LogOutFakeScreen}
+        options={{
+          tabBarIcon: () => (
+            <Pressable onPress={signOut}>
+              <SignOut color={colors.red[400]} size={iconSize} />
+            </Pressable>
+          ),
+        }}
+      />
+    </Navigator>
+  );
+}

--- a/src/screens/MyAdDetails.tsx
+++ b/src/screens/MyAdDetails.tsx
@@ -1,0 +1,174 @@
+import { Button } from '@components/Button';
+import {
+  useFocusEffect,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native';
+import { AppNavigatorRoutesProps } from '@routes/app.routes';
+import {
+  HStack,
+  Pressable,
+  Text,
+  VStack,
+  useTheme,
+  useToast,
+} from 'native-base';
+import {
+  ArrowLeft,
+  PencilSimpleLine,
+  Power,
+  TrashSimple,
+} from 'phosphor-react-native';
+import { api } from '@services/api';
+import { AdDetails } from '@components/AdDetails';
+import { AppError } from '@utils/AppError';
+import { useCallback, useEffect, useState } from 'react';
+import { IProduct } from 'src/interfaces/IProduct';
+import { ProductMap } from '@mappers/ProductMap';
+import { Loading } from '@components/Loading';
+import { HomeTabsNavigatorRoutesProps } from '@routes/home.tabs.routes';
+
+type ParamsProps = {
+  id: string;
+};
+
+export function MyAdDetails() {
+  const { colors, sizes } = useTheme();
+  const toast = useToast();
+  const { navigate } = useNavigation<AppNavigatorRoutesProps>();
+  const { navigate: navigateHomeTabs } =
+    useNavigation<HomeTabsNavigatorRoutesProps>();
+  const route = useRoute();
+
+  const params = route.params as ParamsProps;
+
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [is_active, setIs_active] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [data, setData] = useState<IProduct>({} as IProduct);
+
+  function handleGoBack() {
+    navigateHomeTabs('myAds');
+  }
+
+  function handleNavigateToEditAd() {
+    navigate('createAd', data);
+  }
+
+  async function handleDeleteAd() {
+    try {
+      setIsDeleting(true);
+      await api.delete(`/products/${params.id}`);
+
+      handleGoBack();
+    } catch (error) {
+      const isAppError = error instanceof AppError;
+      const title = isAppError
+        ? error.message
+        : 'Não foi possível excluir o anúncio. Tente novamente mais tarde.';
+
+      toast.show({
+        title,
+        placement: 'top',
+        bgColor: 'red.500',
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  async function handleDisableAd() {
+    try {
+      setIsDeleting(true);
+      const { data } = await api.patch(`/products/${params.id}`, {
+        is_active: !is_active,
+      });
+
+      setIs_active((prev) => !prev);
+    } catch (error) {
+      const isAppError = error instanceof AppError;
+      const title = isAppError
+        ? error.message
+        : 'Não foi possível desativar o anúncio. Tente novamente mais tarde.';
+
+      toast.show({
+        title,
+        placement: 'top',
+        bgColor: 'red.500',
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  async function fetchData() {
+    try {
+      setIsLoading(true);
+
+      const { data } = await api.get(`/products/${params.id}`);
+
+      setData(ProductMap.toIProduct(data));
+    } catch (error) {
+      const isAppError = error instanceof AppError;
+      const title = isAppError
+        ? error.message
+        : 'Não foi possível carregar o anúncio. Tente novamente mais tarde.';
+
+      toast.show({
+        title,
+        placement: 'top',
+        bgColor: 'red.500',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchData();
+    }, [])
+  );
+
+  return (
+    <VStack flex={1}>
+      <HStack
+        safeAreaTop
+        alignItems='center'
+        justifyContent='space-between'
+        p='4'
+      >
+        <Pressable onPress={handleGoBack}>
+          <ArrowLeft size={sizes[6]} color={colors.gray[700]} />
+        </Pressable>
+
+        <Pressable onPress={handleNavigateToEditAd}>
+          <PencilSimpleLine size={sizes[6]} color={colors.gray[700]} />
+        </Pressable>
+      </HStack>
+
+      {isLoading ? <Loading /> : <AdDetails {...data} is_active={is_active} />}
+
+      <VStack safeAreaBottom pt='6' px='6' style={{ gap: 4 }}>
+        <Button
+          alignSelf='center'
+          title={is_active ? 'Desativar anúncio' : 'Reativar anúncio'}
+          bgColor={is_active ? 'gray.700' : 'blue.400'}
+          leftIcon={<Power size={sizes[4]} color={colors.gray[200]} />}
+          onPress={handleDisableAd}
+          isLoading={isUpdating}
+          disabled={isDeleting}
+        />
+        <Button
+          title='Excluir anúncio'
+          bgColor='gray.300'
+          leftIcon={<TrashSimple size={sizes[4]} color={colors.gray[500]} />}
+          isLoading={isDeleting}
+          disabled={isUpdating}
+          onPress={handleDeleteAd}
+        />
+      </VStack>
+    </VStack>
+  );
+}

--- a/src/screens/PreviewAd.tsx
+++ b/src/screens/PreviewAd.tsx
@@ -1,20 +1,129 @@
 import { Button } from '@components/Button';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { AppNavigatorRoutesProps } from '@routes/app.routes';
-import { HStack, Text, VStack, useTheme } from 'native-base';
+import { HStack, Text, VStack, useTheme, useToast } from 'native-base';
 import { ArrowLeft, Tag } from 'phosphor-react-native';
 import { api } from '@services/api';
-import { AdDetails, AdDetailsProps } from '@components/AdDetails';
+import { AdDetails } from '@components/AdDetails';
+import { useState } from 'react';
+import { AppError } from '@utils/AppError';
+import { IPhoto } from 'src/interfaces/IPhoto';
+import { IProduct } from 'src/interfaces/IProduct';
 
 export function PreviewAd() {
   const { colors, sizes } = useTheme();
-  const { navigate } = useNavigation<AppNavigatorRoutesProps>();
+  const { navigate, goBack } = useNavigation<AppNavigatorRoutesProps>();
   const route = useRoute();
+  const toast = useToast();
 
-  const params = route.params as AdDetailsProps;
+  const params = route.params as IProduct & { imagesToDelete: string[] };
+
+  const [isLoading, setIsLoading] = useState(false);
 
   function handleGoBack() {
-    navigate('createAd');
+    goBack();
+  }
+
+  async function handlePublish() {
+    try {
+      setIsLoading(true);
+
+      const { data } = await api.post('/products', {
+        name: params.name,
+        description: params.description,
+        is_new: params.is_new,
+        price: Number(params.price.toFixed(0)),
+        accept_trade: params.accept_trade,
+        payment_methods: params.payment_methods,
+      });
+
+      const formData = new FormData();
+      formData.append('product_id', data.id);
+
+      params.product_images.map((photo) => {
+        formData.append('images', photo as any);
+      });
+
+      await api.post('/products/images', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+
+      navigate('myAdDetails', { id: data.id });
+    } catch (error) {
+      const isAppError = error instanceof AppError;
+      const title = isAppError
+        ? error.message
+        : 'Não foi possível cadastrar o seu produto. Tente novamente mais tarde.';
+
+      toast.show({
+        title,
+        placement: 'top',
+        bgColor: 'red.500',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function handleUpdate() {
+    try {
+      setIsLoading(true);
+      if (params.imagesToDelete.length > 0) {
+        await api.delete('/products/images', {
+          data: { productImagesIds: params.imagesToDelete },
+        });
+      }
+
+      await api.put(`/products/${params.id}`, {
+        name: params.name,
+        description: params.description,
+        is_new: params.is_new,
+        price: Number(params.price.toFixed(0)),
+        accept_trade: params.accept_trade,
+        payment_methods: params.payment_methods,
+      });
+
+      let imagesToUpload = [] as IPhoto[];
+      params.product_images.map((photo) => {
+        if (!photo.uri.match(`${api.defaults.baseURL}/images/`)) {
+          imagesToUpload = [...imagesToUpload, photo];
+        }
+      });
+
+      if (imagesToUpload.length > 0) {
+        const formData = new FormData();
+        formData.append('product_id', params.id as string);
+
+        imagesToUpload.map((photo) => {
+          if (!photo.uri.match(`${api.defaults.baseURL}/images/`)) {
+            formData.append('images', photo as any);
+          }
+        });
+
+        await api.post('/products/images', formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        });
+      }
+
+      navigate('myAdDetails', { id: params.id as string });
+    } catch (error) {
+      const isAppError = error instanceof AppError;
+      const title = isAppError
+        ? error.message
+        : 'Não foi possível atualizar o seu produto. Tente novamente mais tarde.';
+
+      toast.show({
+        title,
+        placement: 'top',
+        bgColor: 'red.500',
+      });
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   return (
@@ -38,6 +147,7 @@ export function PreviewAd() {
           marginRight={2}
           leftIcon={<ArrowLeft size={sizes[4]} color={colors.gray[600]} />}
           onPress={handleGoBack}
+          disabled={isLoading}
         />
         <Button
           title='Publicar'
@@ -45,6 +155,8 @@ export function PreviewAd() {
           bgColor='blue.400'
           leftIcon={<Tag size={sizes[4]} color={colors.gray[200]} />}
           marginLeft={2}
+          onPress={!!params.id ? handleUpdate : handlePublish}
+          isLoading={isLoading}
         />
       </HStack>
     </VStack>

--- a/src/screens/SignUp.tsx
+++ b/src/screens/SignUp.tsx
@@ -16,8 +16,6 @@ import { useNavigation } from '@react-navigation/native';
 import { useForm, Controller } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import EyeSvg from '@assets/eye.svg';
-import EyeSlashSvg from '@assets/eye_slash.svg';
 import LogoSvg from '@assets/logo.svg';
 import { Input } from '@components/Input';
 import { Button } from '@components/Button';
@@ -82,8 +80,6 @@ export function SignUp() {
   const [isLoading, setIsLoading] = useState(false);
 
   function handleGoBack() {
-    console.log('handleGoBack is called');
-
     navigation.goBack();
   }
 
@@ -155,12 +151,6 @@ export function SignUp() {
         } as any;
 
         setPhoto(photoFile);
-
-        // toast.show({
-        //   title: 'Foto selecionada!',
-        //   placement: 'top',
-        //   bgColor: 'green.500',
-        // });
       }
     } catch (error) {
       const isAppError = error instanceof AppError;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -86,8 +86,6 @@ api.registerInterceptTokenManager = (signOut) => {
                   request.onSuccess(data.token);
                 });
 
-                console.log('TOKEN ATUALIZADO');
-
                 resolve(api(originalRequestConfig));
               } catch (error: any) {
                 failedQueue.forEach((request) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
       "@services/*": ["./src/services/*"],
       "@hooks/*": ["./src/hooks/*"],
       "@contexts/*": ["./src/contexts/*"],
-      "@routes/*": ["./src/routes/*"]
+      "@routes/*": ["./src/routes/*"],
+      "@mappers/*": ["./src/mappers/*"]
     }
   }
 }


### PR DESCRIPTION
This pull request includes the following changes:

Here's a brief summary of the commits:

* Add alias for mappers folder in babel.config.js and tsconfig.json.
* Update AdDetails component with changes in props and imports.
* Add disabled overlay and use IPhoto interface.
* Update PaymentMethodsDTO to reflect API data format.
* Create ProductDTO.
* Create ProductImageDTO.
* Changed ProductImagesDTO to ProductImageDTO.
* Create IPaymentMethods.
* Create IPhoto.
* Create IProduct.
* Create PaymentMethodsMap to convert data from PaymentMethodsDTO  to IPaymentMethods.
* Create PhotoMap to convert data from ProductImageDTO to IPhoto.
* Create ProductMap to convert data from ProductDTO to IProduct.
* Create home.tabs routes to isolate routes from stack routes.
* Refactor CreateAd screen with dynamic title, remove unnecessary imports, use IPaymentMethods, and fix bugs in value input.
* Remove unnecessary imports and commented code in SignUp Screen.
* Improve PreviewAd screen by creating handleUpdate function, refactoring handlePublish and handleGoBack, and removing unnecessary imports.
* Create MyAdDetails screen.
* Change app.routes.tsx Navigator to Stack, remove unnecessary code and replace routes with 'homeTabs'