### PR TITLE
Feat/my ads get user products

### DIFF
--- a/src/components/AdDetails.tsx
+++ b/src/components/AdDetails.tsx
@@ -125,7 +125,7 @@ export function AdDetails({
             color='blue.400'
             maxWidth='1/3'
           >
-            R$ <Text fontSize='lg+'>{toMaskedPrice(String(price / 100))}</Text>
+            R$ <Text fontSize='lg+'>{toMaskedPrice(String(price))}</Text>
           </Text>
         </HStack>
 

--- a/src/dtos/ProductDTO.ts
+++ b/src/dtos/ProductDTO.ts
@@ -8,6 +8,7 @@ export type ProductDTO = {
   name: string;
   description: string;
   is_new: boolean;
+  is_active?: boolean;
   price: number;
   accept_trade: boolean;
   payment_methods: PaymentMethodsDTO[];

--- a/src/mappers/ProductMap.ts
+++ b/src/mappers/ProductMap.ts
@@ -17,6 +17,7 @@ class ProductMap {
     product_images,
     user,
     user_id,
+    is_active,
   }: ProductDTO): IProduct {
     return {
       id: id ?? String(uuid.v4()),
@@ -24,6 +25,7 @@ class ProductMap {
       name,
       description,
       is_new,
+      is_active,
       price,
       accept_trade,
       payment_methods: payment_methods.map((item) =>

--- a/src/screens/CreateAd.tsx
+++ b/src/screens/CreateAd.tsx
@@ -47,7 +47,7 @@ export function CreateAd() {
   const [images, setImages] = useState<IPhoto[]>([]);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [isNew, setIsNew] = useState<boolean | null>(null);
+  const [isNew, setIsNew] = useState<string>('');
   const [price, setPrice] = useState('');
   const [acceptTrade, setAcceptTrade] = useState(false);
   const [photoIsLoading, setPhotoIsLoading] = useState(false);
@@ -112,10 +112,12 @@ export function CreateAd() {
     );
   }
 
+  function findPaymentMethod(payment_method: IPaymentMethods) {
+    return paymentMethods.includes(payment_method);
+  }
+
   function handlePaymentMethods(payment_method: IPaymentMethods) {
-    const existMethod = paymentMethods.find(
-      (paymentMethod) => paymentMethod === payment_method
-    );
+    const existMethod = findPaymentMethod(payment_method);
 
     if (existMethod) {
       setPaymentMethods((prev) =>
@@ -151,7 +153,7 @@ export function CreateAd() {
       });
     }
 
-    if (isNew === null) {
+    if (isNew === '') {
       return toast.show({
         title: 'Informe o estado do seu produto.',
         placement: 'top',
@@ -182,7 +184,7 @@ export function CreateAd() {
       product_images: images,
       name,
       description,
-      is_new: isNew,
+      is_new: isNew === 'Produto novo',
       price: rawPrice,
       accept_trade: acceptTrade,
       payment_methods: paymentMethods,
@@ -197,8 +199,8 @@ export function CreateAd() {
       setImages(params.product_images);
       setName(params.name);
       setDescription(params.description);
-      setIsNew(params.is_new);
-      setPrice(toMaskedPrice(String(params.price / 100)));
+      setIsNew(params.is_new ? 'Produto novo' : 'Produto usado');
+      setPrice(toMaskedPrice(String(params.price)));
       setAcceptTrade(params.accept_trade);
       setPaymentMethods(params.payment_methods);
       setIsActive(params?.is_active ?? true);
@@ -314,8 +316,9 @@ export function CreateAd() {
           data={['Produto novo', 'Produto usado']}
           name='Estado do produto'
           accessibilityLabel='Escolha o estado do produto'
+          value={isNew}
           onChange={(newValue) => {
-            setIsNew(newValue === 'Produto novo');
+            setIsNew(newValue);
           }}
         />
 
@@ -364,6 +367,7 @@ export function CreateAd() {
         </Text>
         <Checkbox
           value='boleto'
+          isChecked={findPaymentMethod('boleto')}
           onChange={() => {
             handlePaymentMethods('boleto');
           }}
@@ -371,6 +375,7 @@ export function CreateAd() {
         />
         <Checkbox
           value='pix'
+          isChecked={findPaymentMethod('pix')}
           onChange={() => {
             handlePaymentMethods('pix');
           }}
@@ -378,6 +383,7 @@ export function CreateAd() {
         />
         <Checkbox
           value='cash'
+          isChecked={findPaymentMethod('cash')}
           onChange={() => {
             handlePaymentMethods('cash');
           }}
@@ -385,6 +391,7 @@ export function CreateAd() {
         />
         <Checkbox
           value='card'
+          isChecked={findPaymentMethod('card')}
           onChange={() => {
             handlePaymentMethods('card');
           }}
@@ -392,6 +399,7 @@ export function CreateAd() {
         />
         <Checkbox
           value='deposit'
+          isChecked={findPaymentMethod('deposit')}
           onChange={() => {
             handlePaymentMethods('deposit');
           }}

--- a/src/screens/MyAds.tsx
+++ b/src/screens/MyAds.tsx
@@ -1,5 +1,6 @@
 import { Ads } from '@components/Ads';
-import { useNavigation } from '@react-navigation/native';
+import { useAuth } from '@hooks/useAuth';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { AppNavigatorRoutesProps } from '@routes/app.routes';
 import {
   Center,
@@ -14,18 +15,33 @@ import {
   FlatList,
 } from 'native-base';
 import { CaretDown, CaretUp, Plus } from 'phosphor-react-native';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { IProduct } from 'src/interfaces/IProduct';
 
 export function MyAds() {
   const { colors, sizes } = useTheme();
+  const { userProducts } = useAuth();
   const { navigate } = useNavigation<AppNavigatorRoutesProps>();
 
   const [filter, setFilter] = useState('Todos');
   const [filterIsOpened, setFilterIsOpened] = useState(false);
+  const [data, setData] = useState<IProduct[]>([] as IProduct[]);
 
   function handleOpenCreateAd() {
     navigate('createAd');
   }
+
+  useEffect(() => {
+    if (filter === 'Todos') {
+      setData(userProducts);
+    }
+    if (filter === 'Ativos') {
+      setData(userProducts.filter((product) => product.is_active === true));
+    }
+    if (filter === 'Inativos') {
+      setData(userProducts.filter((product) => product.is_active === false));
+    }
+  }, [filter, userProducts]);
 
   return (
     <VStack flex={1} px='6' safeAreaTop>
@@ -41,7 +57,7 @@ export function MyAds() {
 
       <HStack justifyContent='space-between' alignItems='center'>
         <Text fontFamily='regular' fontSize='sm' color='gray.600'>
-          9 anúncios
+          {userProducts.length} anúncio{userProducts.length > 1 && 's'}
         </Text>
 
         <Menu
@@ -111,10 +127,10 @@ export function MyAds() {
         </Menu>
       </HStack>
 
-      {/* <FlatList
-        data={[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+      <FlatList
+        data={data}
         keyExtractor={(item) => String(item)}
-        renderItem={({ item }) => <Ads showAvatar={false} />}
+        renderItem={({ item }) => <Ads showAvatar={false} {...item} />}
         horizontal={false}
         numColumns={2}
         style={{
@@ -124,7 +140,7 @@ export function MyAds() {
           justifyContent: 'space-between',
         }}
         showsVerticalScrollIndicator={false}
-      /> */}
+      />
     </VStack>
   );
 }

--- a/src/screens/PreviewAd.tsx
+++ b/src/screens/PreviewAd.tsx
@@ -9,12 +9,14 @@ import { useState } from 'react';
 import { AppError } from '@utils/AppError';
 import { IPhoto } from 'src/interfaces/IPhoto';
 import { IProduct } from 'src/interfaces/IProduct';
+import { useAuth } from '@hooks/useAuth';
 
 export function PreviewAd() {
   const { colors, sizes } = useTheme();
   const { navigate, goBack } = useNavigation<AppNavigatorRoutesProps>();
   const route = useRoute();
   const toast = useToast();
+  const { fetchUserProducts } = useAuth();
 
   const params = route.params as IProduct & { imagesToDelete: string[] };
 
@@ -49,6 +51,8 @@ export function PreviewAd() {
           'Content-Type': 'multipart/form-data',
         },
       });
+
+      await fetchUserProducts();
 
       navigate('adDetails', { id: data.id });
     } catch (error) {
@@ -109,6 +113,7 @@ export function PreviewAd() {
         });
       }
 
+      await fetchUserProducts();
       navigate('adDetails', { id: params.id as string });
     } catch (error) {
       const isAppError = error instanceof AppError;


### PR DESCRIPTION
This pull request includes the following changes:

Here's a brief summary of the commits:

* Remove unnecessary price division on AdDetails screen.
* Add 'is_new' into ProductDTO.
* Add 'is_new' into ProductMap params.
* Update user products after delete a product or disable the ad, also fix deleting/updating loading.
* Remove unnecessary price division, create findPaymentMethod function, and turn 'isNew' state to string.
* Use useEffect to get and update screen data based on changes in 'filter' and 'userProducts' context data.
* Update user products after publish or update a ad.
